### PR TITLE
Feature/unix sockets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,11 +4,17 @@ version = "0.2.0"
 dependencies = [
  "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rmp 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unix_socket 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "byteorder"
 version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cfg-if"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -38,9 +44,20 @@ dependencies = [
  "num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
+[[package]]
+name = "unix_socket"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
 [metadata]
 "checksum byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c40977b0ee6b9885c9013cd41d9feffdd22deb3bb4dc3a71d901cc7a77de18c8"
+"checksum cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de1e760d7b6535af4241fca8bd8adf68e2e7edacc6b29f5d399050c5e48cf88c"
 "checksum libc 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "52f45f4d4d75de96cf7f8b0e37b6a8e2f96619749b80bd79aa9f5a3100d63208"
 "checksum log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "038b5d13189a14e5b6ac384fdb7c691a45ef0885f6d2dddbf422e6c3506b8234"
 "checksum num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "a16a42856a256b39c6d3484f097f6713e14feacd9bfb02290917904fae46c81c"
 "checksum rmp 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5a930e81dd6ccc8f8c9cbcd7a622ee4b2aef614781be9b75feaeeea1efbbd96e"
+"checksum unix_socket 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6aa2700417c405c38f5e6902d699345241c28c0b7ade4abaad71e35a87eb1564"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,6 +4,7 @@ version = "0.2.0"
 dependencies = [
  "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rmp 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "unix_socket 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -36,12 +37,28 @@ version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "rand"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rmp"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tempdir"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -59,5 +76,7 @@ dependencies = [
 "checksum libc 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "52f45f4d4d75de96cf7f8b0e37b6a8e2f96619749b80bd79aa9f5a3100d63208"
 "checksum log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "038b5d13189a14e5b6ac384fdb7c691a45ef0885f6d2dddbf422e6c3506b8234"
 "checksum num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "a16a42856a256b39c6d3484f097f6713e14feacd9bfb02290917904fae46c81c"
+"checksum rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "022e0636ec2519ddae48154b028864bdce4eaf7d35226ab8e65c611be97b189d"
 "checksum rmp 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5a930e81dd6ccc8f8c9cbcd7a622ee4b2aef614781be9b75feaeeea1efbbd96e"
+"checksum tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "87974a6f5c1dfb344d733055601650059a3363de2a6104819293baff662132d6"
 "checksum unix_socket 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6aa2700417c405c38f5e6902d699345241c28c0b7ade4abaad71e35a87eb1564"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,6 @@ log = "0.3"
 
 [target.'cfg(unix)'.dependencies]
 unix_socket = "0.5.0"
+
+[dev-dependencies]
+tempdir = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ travis-ci = { repository = "https://github.com/daa84/neovim-lib", branch = "mast
 [dependencies]
 rmp = "0.8"
 log = "0.3"
+unix_socket = "0.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,6 @@ travis-ci = { repository = "https://github.com/daa84/neovim-lib", branch = "mast
 [dependencies]
 rmp = "0.8"
 log = "0.3"
+
+[target.'cfg(unix)'.dependencies]
 unix_socket = "0.5.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,8 @@
 extern crate rmp;
 #[macro_use]
 extern crate log;
+
+#[cfg(unix)]
 extern crate unix_socket;
 
 mod rpc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@
 extern crate rmp;
 #[macro_use]
 extern crate log;
+extern crate unix_socket;
 
 mod rpc;
 #[macro_use]

--- a/src/session.rs
+++ b/src/session.rs
@@ -47,8 +47,8 @@ impl Session {
     #[cfg(unix)]
     /// Connect to nvim instance via unix socket
     pub fn new_unix_socket<P: AsRef<Path>>(path: P) -> Result<Session> {
-        let stream = try!(UnixStream::connect(path));
-        let read = try!(stream.try_clone());
+        let stream = UnixStream::connect(path)?;
+        let read = stream.try_clone()?;
         Ok(Session {
             client: ClientConnection::UnixSocket(Client::new(stream, read)),
             timeout: Some(Duration::new(5, 0)),

--- a/src/session.rs
+++ b/src/session.rs
@@ -8,6 +8,8 @@ use std::thread::JoinHandle;
 use std::time::Duration;
 
 #[cfg(unix)]
+use std::path::Path;
+#[cfg(unix)]
 use unix_socket::UnixStream;
 
 use rpc::value::Value;
@@ -44,7 +46,7 @@ impl Session {
 
     #[cfg(unix)]
     /// Connect to nvim instance via unix socket
-    pub fn new_unix_socket(path: &str) -> Result<Session> {
+    pub fn new_unix_socket<P: AsRef<Path>>(path: P) -> Result<Session> {
         let stream = try!(UnixStream::connect(path));
         let read = try!(stream.try_clone());
         Ok(Session {

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,5 +1,6 @@
 use std::result;
 use std::net::TcpStream;
+use unix_socket::UnixStream;
 use std::io::Result;
 use std::io::{Error, ErrorKind};
 use std::process::Stdio;
@@ -35,6 +36,16 @@ impl Session {
         let read = stream.try_clone()?;
         Ok(Session {
             client: ClientConnection::Tcp(Client::new(stream, read)),
+            timeout: Some(Duration::new(5, 0)),
+        })
+    }
+
+    /// Connect to nvim instance via unix socket
+    pub fn new_unix_socket(path: &str) -> Result<Session> {
+        let stream = try!(UnixStream::connect(path));
+        let read = try!(stream.try_clone());
+        Ok(Session {
+            client: ClientConnection::UnixSocket(Client::new(stream, read)),
             timeout: Some(Duration::new(5, 0)),
         })
     }
@@ -81,6 +92,7 @@ impl Session {
         match self.client {
             ClientConnection::Child(ref mut client, _) => client.start_event_loop_cb(cb),
             ClientConnection::Tcp(ref mut client) => client.start_event_loop_cb(cb),
+            ClientConnection::UnixSocket(ref mut client) => client.start_event_loop_cb(cb),
         }
     }
 
@@ -89,6 +101,7 @@ impl Session {
         match self.client {
             ClientConnection::Child(ref mut client, _) => client.start_event_loop(),
             ClientConnection::Tcp(ref mut client) => client.start_event_loop(),
+            ClientConnection::UnixSocket(ref mut client) => client.start_event_loop(),
         }
     }
 
@@ -97,6 +110,7 @@ impl Session {
         match self.client {
             ClientConnection::Child(ref mut client, _) => client.call(method, args, self.timeout),
             ClientConnection::Tcp(ref mut client) => client.call(method, args, self.timeout),
+            ClientConnection::UnixSocket(ref mut client) => client.call(method, args, self.timeout),
         }
     }
 
@@ -107,6 +121,7 @@ impl Session {
         match self.client {
             ClientConnection::Child(ref mut client, _) => client.take_dispatch_guard(),
             ClientConnection::Tcp(ref mut client) => client.take_dispatch_guard(),
+            ClientConnection::UnixSocket(ref mut client) => client.take_dispatch_guard(),
         }
     }
 }
@@ -114,4 +129,5 @@ impl Session {
 enum ClientConnection {
     Child(Client<ChildStdout, ChildStdin>, Child),
     Tcp(Client<TcpStream, TcpStream>),
+    UnixSocket(Client<UnixStream, UnixStream>),
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,9 +1,14 @@
 extern crate neovim_lib;
 extern crate rmp;
+extern crate tempdir;
 
 use neovim_lib::session::Session;
 use neovim_lib::neovim::Neovim;
 use neovim_lib::neovim_api::NeovimApi;
+use neovim_lib::Value;
+
+use std::process::Command;
+use tempdir::TempDir;
 
 #[ignore]
 #[test]
@@ -40,4 +45,68 @@ fn edit_test() {
     nvim.command("vsplit").unwrap();
     let windows = nvim.get_windows().unwrap();
     windows[0].set_width(&mut nvim, 10).unwrap();
+}
+
+#[cfg(unix)]
+#[ignore]
+#[test]
+fn can_connect_via_unix_socket() {
+    use std::path::Path;
+    use std::thread::sleep;
+    use std::time::{Duration, Instant};
+
+    let dir = TempDir::new("neovim-lib.test").expect("Cannot create temporary directory for test.");
+
+    let socket_path = dir.path().join("unix_socket");
+
+    let _child = Command::new("nvim")
+        .arg("--embed")
+        .env("NVIM_LISTEN_ADDRESS", &socket_path)
+        .spawn()
+        .expect("Cannot start neovim");
+
+    // wait at least 1 second for neovim to start and create socket path.
+    {
+        let start = Instant::now();
+        let one_second = Duration::from_secs(1);
+        loop {
+            sleep(Duration::from_millis(100));
+
+            if let Ok(_) = std::fs::metadata(&socket_path) {
+                break;
+            }
+
+            if one_second <= start.elapsed() {
+                panic!(format!("neovim socket not found at '{:?}'", &socket_path));
+            }
+        }
+    }
+
+
+    let mut session = Session::new_unix_socket(&socket_path)
+        .expect(&format!("Unable to connect to neovim's unix socket at {:?}",
+                         &socket_path));
+
+    session.start_event_loop();
+
+    let mut nvim = Neovim::new(session);
+
+    let servername = nvim.get_vvar("servername")
+        .expect("Error retrieving servername from neovim over unix socket");
+
+    // let's make sure the servername string and socket path string both match.
+    match servername {
+        Value::String(ref name) => {
+            if Path::new(name) != socket_path {
+                panic!(format!("Server name does not match socket path! {} != {}",
+                               name,
+                               socket_path.to_str().unwrap()));
+            }
+        }
+        _ => {
+            panic!(format!("Server name does not match socket path! {:?} != {}",
+                           servername,
+                           socket_path.to_str().unwrap()))
+        }
+    }
 }


### PR DESCRIPTION
I rebased and preserved @mikezaby's commit from #1, added conditional macros to compile unix_sockets support on unix-based OS's, and included a unit test.

Also replaced `try!` macros per the rustfmt.toml.

Tested.

- ArchLinux
- neovim v0.2.0-827-g3f555cce3
- rust toolchain stable-x86_64-unknown-linux-gnu rustc 1.15.1 (021bd294c 2017-02-08)