### PR TITLE
Add support for rpcrequest from vim script

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,4 +32,5 @@ pub use neovim::{Neovim, UiAttachOptions, CallError};
 pub use neovim_api::NeovimApi;
 pub use session::Session;
 
+pub use rpc::handler::{Handler};
 pub use rpc::value::{Value, Integer, Float};

--- a/src/rpc/handler.rs
+++ b/src/rpc/handler.rs
@@ -1,0 +1,13 @@
+use rpc::value::Value;
+
+pub trait Handler {
+    fn handle_notify(&mut self, _name: &str, _args: Vec<Value>) {}
+
+    fn handle_request(&mut self, _name: &str, _args: Vec<Value>) -> Result<Value, Value> {
+        Err(Value::String("Not implemented".to_owned()))
+    }
+}
+
+pub struct DefaultHandler();
+
+impl Handler for DefaultHandler {}

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -1,4 +1,5 @@
 
+pub mod handler;
 pub mod model;
 pub mod value;
 mod client;

--- a/src/rpc/model.rs
+++ b/src/rpc/model.rs
@@ -99,6 +99,9 @@ pub fn encode<W: Write>(writer: &mut W, msg: &RpcMessage) -> Result<(), Box<Erro
             write_value(writer, &val)?;
         }
     };
+
+    writer.flush()?;
+
     Ok(())
 }
 


### PR DESCRIPTION
Make the write socket available to the dispatch thread so an rpc
response may be sent back to the requesting vim script.

Rename `cb` to `notify_handler`.

Add `request_handler` to `start_event_loop_cb`.  Similar to
`notify_handler`, but returns a result to be sent in the rpc response.

Flush buffered write sockets, otherwise vim will wait indefinitely for
the rpc response.

Not certain whether this is a direction you wanted to go.  If not, let me know what you had in mind and I'll try to rewrite this PR to accommodate.