### PR TITLE
Switch Handler to rmp Value

### DIFF
--- a/src/rpc/handler.rs
+++ b/src/rpc/handler.rs
@@ -1,10 +1,10 @@
-use rpc::value::Value;
+use rmpv::Value;
 
 pub trait Handler {
     fn handle_notify(&mut self, _name: &str, _args: Vec<Value>) {}
 
     fn handle_request(&mut self, _name: &str, _args: Vec<Value>) -> Result<Value, Value> {
-        Err(Value::String("Not implemented".to_owned()))
+        Err(Value::from("Not implemented"))
     }
 }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -7,9 +7,6 @@ use neovim_lib::neovim::Neovim;
 use neovim_lib::neovim_api::NeovimApi;
 
 #[cfg(unix)]
-use neovim_lib::Value;
-
-#[cfg(unix)]
 use std::process::Command;
 #[cfg(unix)]
 use tempdir::TempDir;
@@ -99,15 +96,15 @@ fn can_connect_via_unix_socket() {
         .expect("Error retrieving servername from neovim over unix socket");
 
     // let's make sure the servername string and socket path string both match.
-    match servername {
-        Value::String(ref name) => {
+    match servername.as_str() {
+        Some(ref name) => {
             if Path::new(name) != socket_path {
                 panic!(format!("Server name does not match socket path! {} != {}",
                                name,
                                socket_path.to_str().unwrap()));
             }
         }
-        _ => {
+        None => {
             panic!(format!("Server name does not match socket path! {:?} != {}",
                            servername,
                            socket_path.to_str().unwrap()))


### PR DESCRIPTION
One extra change needed.  If you'd rather write the change yourself instead of merge, I'd accept that.

I branched the neovim-scorched-earth plugin\[[1]] to test your `rmpv` branch, and it works very well.

With regard to parsing, I might keep my `args` module for now, since I required `Result` types instead of `Option`s.  The `Option` will be excellent when a default value is used.  And if I find I rely on my `args` module often, I can just split it off into a separate crate.  I do like how simple my parsing routines became using `rmp::Value`!

[1]: https://github.com/boxofrox/neovim-scorched-earth/commits/test/rmpv
\[[1]]: https://github.com/boxofrox/neovim-scorched-earth/commits/test/rmpv