### PR TITLE
Allow negative index for nvim_buf_set_lines

### DIFF
--- a/bindings/generate_bindings.py
+++ b/bindings/generate_bindings.py
@@ -50,9 +50,9 @@ class NeovimTypeVal:
     # msgpack simple types types
     SIMPLETYPES_REF = {
             'Array': 'Vec<Value>',
-            'ArrayOf(Integer, 2)': '(u64, u64)',
+            'ArrayOf(Integer, 2)': '(i64, i64)',
             'void': '()',
-            'Integer': 'u64',
+            'Integer': 'i64',
             'Boolean': 'bool',
             'String': '&str',
             'Object': 'Value',
@@ -61,9 +61,9 @@ class NeovimTypeVal:
 
     SIMPLETYPES_VAL = {
             'Array': 'Vec<Value>',
-            'ArrayOf(Integer, 2)': '(u64, u64)',
+            'ArrayOf(Integer, 2)': '(i64, i64)',
             'void': '()',
-            'Integer': 'u64',
+            'Integer': 'i64',
             'Boolean': 'bool',
             'String': 'String',
             'Object': 'Value',

--- a/src/neovim.rs
+++ b/src/neovim.rs
@@ -104,7 +104,7 @@ impl UiAttachOptions {
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum CallError {
     GenericError(String),
-    NeovimError(u64, String),
+    NeovimError(i64, String),
 }
 
 impl fmt::Display for CallError {
@@ -133,7 +133,7 @@ pub fn map_generic_error(err: Value) -> CallError {
             if arr.len() == 2 {
                 match (&arr[0], &arr[1]) {
                     (&Value::Integer(ref id), &Value::String(ref val)) => CallError::NeovimError(
-                        id.as_u64().unwrap(),
+                        id.as_i64().unwrap(),
                         val.as_str().unwrap().to_owned(),
                     ),
                     _ => CallError::GenericError(format!("{:?}", arr)),
@@ -161,8 +161,8 @@ impl Neovim {
     /// After this method is called, the client will receive redraw notifications.
     pub fn ui_attach(
         &mut self,
-        width: u64,
-        height: u64,
+        width: i64,
+        height: i64,
         opts: &UiAttachOptions,
     ) -> Result<(), CallError> {
         self.session

--- a/src/neovim_api.rs
+++ b/src/neovim_api.rs
@@ -73,8 +73,8 @@ impl Buffer {
     pub fn set_lines(
         &self,
         neovim: &mut Neovim,
-        start: i64,
-        end: i64,
+        start: u64,
+        end: u64,
         strict_indexing: bool,
         replacement: Vec<String>,
     ) -> Result<(), CallError> {

--- a/src/neovim_api.rs
+++ b/src/neovim_api.rs
@@ -1,4 +1,4 @@
-// Auto generated 2018-06-13 13:04:47.609000
+// Auto generated 2018-10-16 23:09:58.153601
 
 use neovim::*;
 use rpc::*;
@@ -10,9 +10,7 @@ pub struct Buffer {
 
 impl Buffer {
     pub fn new(code_data: Value) -> Buffer {
-        Buffer {
-            code_data: code_data,
-        }
+        Buffer { code_data }
     }
 
     /// Internal value, that represent type
@@ -21,7 +19,7 @@ impl Buffer {
     }
 
     /// since: 1
-    pub fn line_count(&self, neovim: &mut Neovim) -> Result<u64, CallError> {
+    pub fn line_count(&self, neovim: &mut Neovim) -> Result<i64, CallError> {
         neovim
             .session
             .call("nvim_buf_line_count", call_args![self.code_data.clone()])
@@ -40,8 +38,7 @@ impl Buffer {
             .call(
                 "nvim_buf_attach",
                 call_args![self.code_data.clone(), send_buffer, opts],
-            )
-            .map(map_result)
+            ).map(map_result)
             .map_err(map_generic_error)
     }
     /// since: 4
@@ -56,8 +53,8 @@ impl Buffer {
     pub fn get_lines(
         &self,
         neovim: &mut Neovim,
-        start: u64,
-        end: u64,
+        start: i64,
+        end: i64,
         strict_indexing: bool,
     ) -> Result<Vec<String>, CallError> {
         neovim
@@ -65,16 +62,15 @@ impl Buffer {
             .call(
                 "nvim_buf_get_lines",
                 call_args![self.code_data.clone(), start, end, strict_indexing],
-            )
-            .map(map_result)
+            ).map(map_result)
             .map_err(map_generic_error)
     }
     /// since: 1
     pub fn set_lines(
         &self,
         neovim: &mut Neovim,
-        start: u64,
-        end: u64,
+        start: i64,
+        end: i64,
         strict_indexing: bool,
         replacement: Vec<String>,
     ) -> Result<(), CallError> {
@@ -89,8 +85,7 @@ impl Buffer {
                     strict_indexing,
                     replacement
                 ],
-            )
-            .map(map_result)
+            ).map(map_result)
             .map_err(map_generic_error)
     }
     /// since: 1
@@ -102,14 +97,13 @@ impl Buffer {
             .map_err(map_generic_error)
     }
     /// since: 2
-    pub fn get_changedtick(&self, neovim: &mut Neovim) -> Result<u64, CallError> {
+    pub fn get_changedtick(&self, neovim: &mut Neovim) -> Result<i64, CallError> {
         neovim
             .session
             .call(
                 "nvim_buf_get_changedtick",
                 call_args![self.code_data.clone()],
-            )
-            .map(map_result)
+            ).map(map_result)
             .map_err(map_generic_error)
     }
     /// since: 3
@@ -123,8 +117,7 @@ impl Buffer {
             .call(
                 "nvim_buf_get_keymap",
                 call_args![self.code_data.clone(), mode],
-            )
-            .map(map_result)
+            ).map(map_result)
             .map_err(map_generic_error)
     }
     /// since: 4
@@ -138,8 +131,7 @@ impl Buffer {
             .call(
                 "nvim_buf_get_commands",
                 call_args![self.code_data.clone(), opts],
-            )
-            .map(map_result)
+            ).map(map_result)
             .map_err(map_generic_error)
     }
     /// since: 1
@@ -149,8 +141,7 @@ impl Buffer {
             .call(
                 "nvim_buf_set_var",
                 call_args![self.code_data.clone(), name, value],
-            )
-            .map(map_result)
+            ).map(map_result)
             .map_err(map_generic_error)
     }
     /// since: 1
@@ -168,8 +159,7 @@ impl Buffer {
             .call(
                 "nvim_buf_get_option",
                 call_args![self.code_data.clone(), name],
-            )
-            .map(map_result)
+            ).map(map_result)
             .map_err(map_generic_error)
     }
     /// since: 1
@@ -184,12 +174,11 @@ impl Buffer {
             .call(
                 "nvim_buf_set_option",
                 call_args![self.code_data.clone(), name, value],
-            )
-            .map(map_result)
+            ).map(map_result)
             .map_err(map_generic_error)
     }
     /// since: 1
-    pub fn get_number(&self, neovim: &mut Neovim) -> Result<u64, CallError> {
+    pub fn get_number(&self, neovim: &mut Neovim) -> Result<i64, CallError> {
         neovim
             .session
             .call("nvim_buf_get_number", call_args![self.code_data.clone()])
@@ -211,8 +200,7 @@ impl Buffer {
             .call(
                 "nvim_buf_set_name",
                 call_args![self.code_data.clone(), name],
-            )
-            .map(map_result)
+            ).map(map_result)
             .map_err(map_generic_error)
     }
     /// since: 1
@@ -224,26 +212,25 @@ impl Buffer {
             .map_err(map_generic_error)
     }
     /// since: 1
-    pub fn get_mark(&self, neovim: &mut Neovim, name: &str) -> Result<(u64, u64), CallError> {
+    pub fn get_mark(&self, neovim: &mut Neovim, name: &str) -> Result<(i64, i64), CallError> {
         neovim
             .session
             .call(
                 "nvim_buf_get_mark",
                 call_args![self.code_data.clone(), name],
-            )
-            .map(map_result)
+            ).map(map_result)
             .map_err(map_generic_error)
     }
     /// since: 1
     pub fn add_highlight(
         &self,
         neovim: &mut Neovim,
-        src_id: u64,
+        src_id: i64,
         hl_group: &str,
-        line: u64,
-        col_start: u64,
-        col_end: u64,
-    ) -> Result<u64, CallError> {
+        line: i64,
+        col_start: i64,
+        col_end: i64,
+    ) -> Result<i64, CallError> {
         neovim
             .session
             .call(
@@ -256,25 +243,23 @@ impl Buffer {
                     col_start,
                     col_end
                 ],
-            )
-            .map(map_result)
+            ).map(map_result)
             .map_err(map_generic_error)
     }
     /// since: 1
     pub fn clear_highlight(
         &self,
         neovim: &mut Neovim,
-        src_id: u64,
-        line_start: u64,
-        line_end: u64,
+        src_id: i64,
+        line_start: i64,
+        line_end: i64,
     ) -> Result<(), CallError> {
         neovim
             .session
             .call(
                 "nvim_buf_clear_highlight",
                 call_args![self.code_data.clone(), src_id, line_start, line_end],
-            )
-            .map(map_result)
+            ).map(map_result)
             .map_err(map_generic_error)
     }
 }
@@ -286,9 +271,7 @@ pub struct Window {
 
 impl Window {
     pub fn new(code_data: Value) -> Window {
-        Window {
-            code_data: code_data,
-        }
+        Window { code_data }
     }
 
     /// Internal value, that represent type
@@ -305,7 +288,7 @@ impl Window {
             .map_err(map_generic_error)
     }
     /// since: 1
-    pub fn get_cursor(&self, neovim: &mut Neovim) -> Result<(u64, u64), CallError> {
+    pub fn get_cursor(&self, neovim: &mut Neovim) -> Result<(i64, i64), CallError> {
         neovim
             .session
             .call("nvim_win_get_cursor", call_args![self.code_data.clone()])
@@ -313,18 +296,17 @@ impl Window {
             .map_err(map_generic_error)
     }
     /// since: 1
-    pub fn set_cursor(&self, neovim: &mut Neovim, pos: (u64, u64)) -> Result<(), CallError> {
+    pub fn set_cursor(&self, neovim: &mut Neovim, pos: (i64, i64)) -> Result<(), CallError> {
         neovim
             .session
             .call(
                 "nvim_win_set_cursor",
                 call_args![self.code_data.clone(), pos],
-            )
-            .map(map_result)
+            ).map(map_result)
             .map_err(map_generic_error)
     }
     /// since: 1
-    pub fn get_height(&self, neovim: &mut Neovim) -> Result<u64, CallError> {
+    pub fn get_height(&self, neovim: &mut Neovim) -> Result<i64, CallError> {
         neovim
             .session
             .call("nvim_win_get_height", call_args![self.code_data.clone()])
@@ -332,18 +314,17 @@ impl Window {
             .map_err(map_generic_error)
     }
     /// since: 1
-    pub fn set_height(&self, neovim: &mut Neovim, height: u64) -> Result<(), CallError> {
+    pub fn set_height(&self, neovim: &mut Neovim, height: i64) -> Result<(), CallError> {
         neovim
             .session
             .call(
                 "nvim_win_set_height",
                 call_args![self.code_data.clone(), height],
-            )
-            .map(map_result)
+            ).map(map_result)
             .map_err(map_generic_error)
     }
     /// since: 1
-    pub fn get_width(&self, neovim: &mut Neovim) -> Result<u64, CallError> {
+    pub fn get_width(&self, neovim: &mut Neovim) -> Result<i64, CallError> {
         neovim
             .session
             .call("nvim_win_get_width", call_args![self.code_data.clone()])
@@ -351,14 +332,13 @@ impl Window {
             .map_err(map_generic_error)
     }
     /// since: 1
-    pub fn set_width(&self, neovim: &mut Neovim, width: u64) -> Result<(), CallError> {
+    pub fn set_width(&self, neovim: &mut Neovim, width: i64) -> Result<(), CallError> {
         neovim
             .session
             .call(
                 "nvim_win_set_width",
                 call_args![self.code_data.clone(), width],
-            )
-            .map(map_result)
+            ).map(map_result)
             .map_err(map_generic_error)
     }
     /// since: 1
@@ -376,8 +356,7 @@ impl Window {
             .call(
                 "nvim_win_set_var",
                 call_args![self.code_data.clone(), name, value],
-            )
-            .map(map_result)
+            ).map(map_result)
             .map_err(map_generic_error)
     }
     /// since: 1
@@ -395,8 +374,7 @@ impl Window {
             .call(
                 "nvim_win_get_option",
                 call_args![self.code_data.clone(), name],
-            )
-            .map(map_result)
+            ).map(map_result)
             .map_err(map_generic_error)
     }
     /// since: 1
@@ -411,12 +389,11 @@ impl Window {
             .call(
                 "nvim_win_set_option",
                 call_args![self.code_data.clone(), name, value],
-            )
-            .map(map_result)
+            ).map(map_result)
             .map_err(map_generic_error)
     }
     /// since: 1
-    pub fn get_position(&self, neovim: &mut Neovim) -> Result<(u64, u64), CallError> {
+    pub fn get_position(&self, neovim: &mut Neovim) -> Result<(i64, i64), CallError> {
         neovim
             .session
             .call("nvim_win_get_position", call_args![self.code_data.clone()])
@@ -432,7 +409,7 @@ impl Window {
             .map_err(map_generic_error)
     }
     /// since: 1
-    pub fn get_number(&self, neovim: &mut Neovim) -> Result<u64, CallError> {
+    pub fn get_number(&self, neovim: &mut Neovim) -> Result<i64, CallError> {
         neovim
             .session
             .call("nvim_win_get_number", call_args![self.code_data.clone()])
@@ -456,9 +433,7 @@ pub struct Tabpage {
 
 impl Tabpage {
     pub fn new(code_data: Value) -> Tabpage {
-        Tabpage {
-            code_data: code_data,
-        }
+        Tabpage { code_data }
     }
 
     /// Internal value, that represent type
@@ -481,8 +456,7 @@ impl Tabpage {
             .call(
                 "nvim_tabpage_get_var",
                 call_args![self.code_data.clone(), name],
-            )
-            .map(map_result)
+            ).map(map_result)
             .map_err(map_generic_error)
     }
     /// since: 1
@@ -492,8 +466,7 @@ impl Tabpage {
             .call(
                 "nvim_tabpage_set_var",
                 call_args![self.code_data.clone(), name, value],
-            )
-            .map(map_result)
+            ).map(map_result)
             .map_err(map_generic_error)
     }
     /// since: 1
@@ -503,8 +476,7 @@ impl Tabpage {
             .call(
                 "nvim_tabpage_del_var",
                 call_args![self.code_data.clone(), name],
-            )
-            .map(map_result)
+            ).map(map_result)
             .map_err(map_generic_error)
     }
     /// since: 1
@@ -516,14 +488,13 @@ impl Tabpage {
             .map_err(map_generic_error)
     }
     /// since: 1
-    pub fn get_number(&self, neovim: &mut Neovim) -> Result<u64, CallError> {
+    pub fn get_number(&self, neovim: &mut Neovim) -> Result<i64, CallError> {
         neovim
             .session
             .call(
                 "nvim_tabpage_get_number",
                 call_args![self.code_data.clone()],
-            )
-            .map(map_result)
+            ).map(map_result)
             .map_err(map_generic_error)
     }
     /// since: 1
@@ -574,7 +545,7 @@ pub trait NeovimApi {
     /// since: 1
     fn ui_detach(&mut self) -> Result<(), CallError>;
     /// since: 1
-    fn ui_try_resize(&mut self, width: u64, height: u64) -> Result<(), CallError>;
+    fn ui_try_resize(&mut self, width: i64, height: i64) -> Result<(), CallError>;
     /// since: 1
     fn ui_set_option(&mut self, name: &str, value: Value) -> Result<(), CallError>;
     /// since: 1
@@ -582,11 +553,11 @@ pub trait NeovimApi {
     /// since: 3
     fn get_hl_by_name(&mut self, name: &str, rgb: bool) -> Result<Vec<(Value, Value)>, CallError>;
     /// since: 3
-    fn get_hl_by_id(&mut self, hl_id: u64, rgb: bool) -> Result<Vec<(Value, Value)>, CallError>;
+    fn get_hl_by_id(&mut self, hl_id: i64, rgb: bool) -> Result<Vec<(Value, Value)>, CallError>;
     /// since: 1
     fn feedkeys(&mut self, keys: &str, mode: &str, escape_csi: bool) -> Result<(), CallError>;
     /// since: 1
-    fn input(&mut self, keys: &str) -> Result<u64, CallError>;
+    fn input(&mut self, keys: &str) -> Result<i64, CallError>;
     /// since: 1
     fn replace_termcodes(
         &mut self,
@@ -611,7 +582,7 @@ pub trait NeovimApi {
         args: Vec<Value>,
     ) -> Result<Value, CallError>;
     /// since: 1
-    fn strwidth(&mut self, text: &str) -> Result<u64, CallError>;
+    fn strwidth(&mut self, text: &str) -> Result<i64, CallError>;
     /// since: 1
     fn list_runtime_paths(&mut self) -> Result<Vec<String>, CallError>;
     /// since: 1
@@ -663,7 +634,7 @@ pub trait NeovimApi {
     /// since: 1
     fn unsubscribe(&mut self, event: &str) -> Result<(), CallError>;
     /// since: 1
-    fn get_color_by_name(&mut self, name: &str) -> Result<u64, CallError>;
+    fn get_color_by_name(&mut self, name: &str) -> Result<i64, CallError>;
     /// since: 1
     fn get_color_map(&mut self) -> Result<Vec<(Value, Value)>, CallError>;
     /// since: 2
@@ -685,7 +656,7 @@ pub trait NeovimApi {
         attributes: Vec<(Value, Value)>,
     ) -> Result<(), CallError>;
     /// since: 4
-    fn get_chan_info(&mut self, chan: u64) -> Result<Vec<(Value, Value)>, CallError>;
+    fn get_chan_info(&mut self, chan: i64) -> Result<Vec<(Value, Value)>, CallError>;
     /// since: 4
     fn list_chans(&mut self) -> Result<Vec<Value>, CallError>;
     /// since: 1
@@ -700,9 +671,9 @@ pub trait NeovimApi {
     /// since: 4
     fn list_uis(&mut self) -> Result<Vec<Value>, CallError>;
     /// since: 4
-    fn get_proc_children(&mut self, pid: u64) -> Result<Vec<Value>, CallError>;
+    fn get_proc_children(&mut self, pid: i64) -> Result<Vec<Value>, CallError>;
     /// since: 4
-    fn get_proc(&mut self, pid: u64) -> Result<Value, CallError>;
+    fn get_proc(&mut self, pid: i64) -> Result<Value, CallError>;
 }
 
 impl NeovimApi for Neovim {
@@ -713,7 +684,7 @@ impl NeovimApi for Neovim {
             .map_err(map_generic_error)
     }
 
-    fn ui_try_resize(&mut self, width: u64, height: u64) -> Result<(), CallError> {
+    fn ui_try_resize(&mut self, width: i64, height: i64) -> Result<(), CallError> {
         self.session
             .call("nvim_ui_try_resize", call_args![width, height])
             .map(map_result)
@@ -741,7 +712,7 @@ impl NeovimApi for Neovim {
             .map_err(map_generic_error)
     }
 
-    fn get_hl_by_id(&mut self, hl_id: u64, rgb: bool) -> Result<Vec<(Value, Value)>, CallError> {
+    fn get_hl_by_id(&mut self, hl_id: i64, rgb: bool) -> Result<Vec<(Value, Value)>, CallError> {
         self.session
             .call("nvim_get_hl_by_id", call_args![hl_id, rgb])
             .map(map_result)
@@ -755,7 +726,7 @@ impl NeovimApi for Neovim {
             .map_err(map_generic_error)
     }
 
-    fn input(&mut self, keys: &str) -> Result<u64, CallError> {
+    fn input(&mut self, keys: &str) -> Result<i64, CallError> {
         self.session
             .call("nvim_input", call_args![keys])
             .map(map_result)
@@ -773,8 +744,7 @@ impl NeovimApi for Neovim {
             .call(
                 "nvim_replace_termcodes",
                 call_args![str, from_part, do_lt, special],
-            )
-            .map(map_result)
+            ).map(map_result)
             .map_err(map_generic_error)
     }
 
@@ -818,7 +788,7 @@ impl NeovimApi for Neovim {
             .map_err(map_generic_error)
     }
 
-    fn strwidth(&mut self, text: &str) -> Result<u64, CallError> {
+    fn strwidth(&mut self, text: &str) -> Result<i64, CallError> {
         self.session
             .call("nvim_strwidth", call_args![text])
             .map(map_result)
@@ -1000,7 +970,7 @@ impl NeovimApi for Neovim {
             .map_err(map_generic_error)
     }
 
-    fn get_color_by_name(&mut self, name: &str) -> Result<u64, CallError> {
+    fn get_color_by_name(&mut self, name: &str) -> Result<i64, CallError> {
         self.session
             .call("nvim_get_color_by_name", call_args![name])
             .map(map_result)
@@ -1057,12 +1027,11 @@ impl NeovimApi for Neovim {
             .call(
                 "nvim_set_client_info",
                 call_args![name, version, typ, methods, attributes],
-            )
-            .map(map_result)
+            ).map(map_result)
             .map_err(map_generic_error)
     }
 
-    fn get_chan_info(&mut self, chan: u64) -> Result<Vec<(Value, Value)>, CallError> {
+    fn get_chan_info(&mut self, chan: i64) -> Result<Vec<(Value, Value)>, CallError> {
         self.session
             .call("nvim_get_chan_info", call_args![chan])
             .map(map_result)
@@ -1102,14 +1071,14 @@ impl NeovimApi for Neovim {
             .map_err(map_generic_error)
     }
 
-    fn get_proc_children(&mut self, pid: u64) -> Result<Vec<Value>, CallError> {
+    fn get_proc_children(&mut self, pid: i64) -> Result<Vec<Value>, CallError> {
         self.session
             .call("nvim_get_proc_children", call_args![pid])
             .map(map_result)
             .map_err(map_generic_error)
     }
 
-    fn get_proc(&mut self, pid: u64) -> Result<Value, CallError> {
+    fn get_proc(&mut self, pid: i64) -> Result<Value, CallError> {
         self.session
             .call("nvim_get_proc", call_args![pid])
             .map(map_result)

--- a/src/neovim_api.rs
+++ b/src/neovim_api.rs
@@ -73,8 +73,8 @@ impl Buffer {
     pub fn set_lines(
         &self,
         neovim: &mut Neovim,
-        start: u64,
-        end: u64,
+        start: i64,
+        end: i64,
         strict_indexing: bool,
         replacement: Vec<String>,
     ) -> Result<(), CallError> {

--- a/src/neovim_api_async.rs
+++ b/src/neovim_api_async.rs
@@ -1,4 +1,4 @@
-// Auto generated 2018-06-13 13:04:47.747000
+// Auto generated 2018-10-16 23:09:58.123979
 
 use async::AsyncCall;
 use neovim::*;
@@ -9,7 +9,7 @@ pub trait NeovimApiAsync {
     /// since: 1
     fn ui_detach_async(&mut self) -> AsyncCall<()>;
     /// since: 1
-    fn ui_try_resize_async(&mut self, width: u64, height: u64) -> AsyncCall<()>;
+    fn ui_try_resize_async(&mut self, width: i64, height: i64) -> AsyncCall<()>;
     /// since: 1
     fn ui_set_option_async(&mut self, name: &str, value: Value) -> AsyncCall<()>;
     /// since: 1
@@ -17,11 +17,11 @@ pub trait NeovimApiAsync {
     /// since: 3
     fn get_hl_by_name_async(&mut self, name: &str, rgb: bool) -> AsyncCall<Vec<(Value, Value)>>;
     /// since: 3
-    fn get_hl_by_id_async(&mut self, hl_id: u64, rgb: bool) -> AsyncCall<Vec<(Value, Value)>>;
+    fn get_hl_by_id_async(&mut self, hl_id: i64, rgb: bool) -> AsyncCall<Vec<(Value, Value)>>;
     /// since: 1
     fn feedkeys_async(&mut self, keys: &str, mode: &str, escape_csi: bool) -> AsyncCall<()>;
     /// since: 1
-    fn input_async(&mut self, keys: &str) -> AsyncCall<u64>;
+    fn input_async(&mut self, keys: &str) -> AsyncCall<i64>;
     /// since: 1
     fn replace_termcodes_async(
         &mut self,
@@ -46,7 +46,7 @@ pub trait NeovimApiAsync {
         args: Vec<Value>,
     ) -> AsyncCall<Value>;
     /// since: 1
-    fn strwidth_async(&mut self, text: &str) -> AsyncCall<u64>;
+    fn strwidth_async(&mut self, text: &str) -> AsyncCall<i64>;
     /// since: 1
     fn list_runtime_paths_async(&mut self) -> AsyncCall<Vec<String>>;
     /// since: 1
@@ -98,7 +98,7 @@ pub trait NeovimApiAsync {
     /// since: 1
     fn unsubscribe_async(&mut self, event: &str) -> AsyncCall<()>;
     /// since: 1
-    fn get_color_by_name_async(&mut self, name: &str) -> AsyncCall<u64>;
+    fn get_color_by_name_async(&mut self, name: &str) -> AsyncCall<i64>;
     /// since: 1
     fn get_color_map_async(&mut self) -> AsyncCall<Vec<(Value, Value)>>;
     /// since: 2
@@ -119,7 +119,7 @@ pub trait NeovimApiAsync {
         attributes: Vec<(Value, Value)>,
     ) -> AsyncCall<()>;
     /// since: 4
-    fn get_chan_info_async(&mut self, chan: u64) -> AsyncCall<Vec<(Value, Value)>>;
+    fn get_chan_info_async(&mut self, chan: i64) -> AsyncCall<Vec<(Value, Value)>>;
     /// since: 4
     fn list_chans_async(&mut self) -> AsyncCall<Vec<Value>>;
     /// since: 1
@@ -134,9 +134,9 @@ pub trait NeovimApiAsync {
     /// since: 4
     fn list_uis_async(&mut self) -> AsyncCall<Vec<Value>>;
     /// since: 4
-    fn get_proc_children_async(&mut self, pid: u64) -> AsyncCall<Vec<Value>>;
+    fn get_proc_children_async(&mut self, pid: i64) -> AsyncCall<Vec<Value>>;
     /// since: 4
-    fn get_proc_async(&mut self, pid: u64) -> AsyncCall<Value>;
+    fn get_proc_async(&mut self, pid: i64) -> AsyncCall<Value>;
 }
 
 impl NeovimApiAsync for Neovim {
@@ -145,7 +145,7 @@ impl NeovimApiAsync for Neovim {
             .call_async::<()>("nvim_ui_detach", call_args![])
     }
 
-    fn ui_try_resize_async(&mut self, width: u64, height: u64) -> AsyncCall<()> {
+    fn ui_try_resize_async(&mut self, width: i64, height: i64) -> AsyncCall<()> {
         self.session
             .call_async::<()>("nvim_ui_try_resize", call_args![width, height])
     }
@@ -165,7 +165,7 @@ impl NeovimApiAsync for Neovim {
             .call_async::<Vec<(Value, Value)>>("nvim_get_hl_by_name", call_args![name, rgb])
     }
 
-    fn get_hl_by_id_async(&mut self, hl_id: u64, rgb: bool) -> AsyncCall<Vec<(Value, Value)>> {
+    fn get_hl_by_id_async(&mut self, hl_id: i64, rgb: bool) -> AsyncCall<Vec<(Value, Value)>> {
         self.session
             .call_async::<Vec<(Value, Value)>>("nvim_get_hl_by_id", call_args![hl_id, rgb])
     }
@@ -175,9 +175,9 @@ impl NeovimApiAsync for Neovim {
             .call_async::<()>("nvim_feedkeys", call_args![keys, mode, escape_csi])
     }
 
-    fn input_async(&mut self, keys: &str) -> AsyncCall<u64> {
+    fn input_async(&mut self, keys: &str) -> AsyncCall<i64> {
         self.session
-            .call_async::<u64>("nvim_input", call_args![keys])
+            .call_async::<i64>("nvim_input", call_args![keys])
     }
 
     fn replace_termcodes_async(
@@ -223,9 +223,9 @@ impl NeovimApiAsync for Neovim {
             .call_async::<Value>("nvim_call_dict_function", call_args![dict, fname, args])
     }
 
-    fn strwidth_async(&mut self, text: &str) -> AsyncCall<u64> {
+    fn strwidth_async(&mut self, text: &str) -> AsyncCall<i64> {
         self.session
-            .call_async::<u64>("nvim_strwidth", call_args![text])
+            .call_async::<i64>("nvim_strwidth", call_args![text])
     }
 
     fn list_runtime_paths_async(&mut self) -> AsyncCall<Vec<String>> {
@@ -353,9 +353,9 @@ impl NeovimApiAsync for Neovim {
             .call_async::<()>("nvim_unsubscribe", call_args![event])
     }
 
-    fn get_color_by_name_async(&mut self, name: &str) -> AsyncCall<u64> {
+    fn get_color_by_name_async(&mut self, name: &str) -> AsyncCall<i64> {
         self.session
-            .call_async::<u64>("nvim_get_color_by_name", call_args![name])
+            .call_async::<i64>("nvim_get_color_by_name", call_args![name])
     }
 
     fn get_color_map_async(&mut self) -> AsyncCall<Vec<(Value, Value)>> {
@@ -397,7 +397,7 @@ impl NeovimApiAsync for Neovim {
         )
     }
 
-    fn get_chan_info_async(&mut self, chan: u64) -> AsyncCall<Vec<(Value, Value)>> {
+    fn get_chan_info_async(&mut self, chan: i64) -> AsyncCall<Vec<(Value, Value)>> {
         self.session
             .call_async::<Vec<(Value, Value)>>("nvim_get_chan_info", call_args![chan])
     }
@@ -429,12 +429,12 @@ impl NeovimApiAsync for Neovim {
             .call_async::<Vec<Value>>("nvim_list_uis", call_args![])
     }
 
-    fn get_proc_children_async(&mut self, pid: u64) -> AsyncCall<Vec<Value>> {
+    fn get_proc_children_async(&mut self, pid: i64) -> AsyncCall<Vec<Value>> {
         self.session
             .call_async::<Vec<Value>>("nvim_get_proc_children", call_args![pid])
     }
 
-    fn get_proc_async(&mut self, pid: u64) -> AsyncCall<Value> {
+    fn get_proc_async(&mut self, pid: i64) -> AsyncCall<Value> {
         self.session
             .call_async::<Value>("nvim_get_proc", call_args![pid])
     }

--- a/src/rpc/client.rs
+++ b/src/rpc/client.rs
@@ -11,7 +11,7 @@ use rmpv::Value;
 use super::model;
 
 type Callback = Box<FnMut(Result<Value, Value>) + Send + 'static>;
-type Queue = Arc<Mutex<Vec<(i64, Sender)>>>;
+type Queue = Arc<Mutex<Vec<(u64, Sender)>>>;
 
 enum Sender {
     Sync(mpsc::Sender<Result<Value, Value>>),
@@ -37,7 +37,7 @@ where
     dispatch_guard: Option<JoinHandle<()>>,
     event_loop_started: bool,
     queue: Queue,
-    msgid_counter: i64,
+    msgid_counter: u64,
 }
 
 impl<R, W> Client<R, W>
@@ -266,7 +266,7 @@ where
  * is that Vec is faster on small queue sizes
  * in most cases Vec.len = 1 so we just take first item in iteration.
  */
-fn find_sender(queue: &Queue, msgid: i64) -> Sender {
+fn find_sender(queue: &Queue, msgid: u64) -> Sender {
     let mut queue = queue.lock().unwrap();
 
     let pos = queue.iter().position(|req| req.0 == msgid).unwrap();

--- a/src/rpc/client.rs
+++ b/src/rpc/client.rs
@@ -11,7 +11,7 @@ use rmpv::Value;
 use super::model;
 
 type Callback = Box<FnMut(Result<Value, Value>) + Send + 'static>;
-type Queue = Arc<Mutex<Vec<(u64, Sender)>>>;
+type Queue = Arc<Mutex<Vec<(i64, Sender)>>>;
 
 enum Sender {
     Sync(mpsc::Sender<Result<Value, Value>>),
@@ -37,7 +37,7 @@ where
     dispatch_guard: Option<JoinHandle<()>>,
     event_loop_started: bool,
     queue: Queue,
-    msgid_counter: u64,
+    msgid_counter: i64,
 }
 
 impl<R, W> Client<R, W>
@@ -266,7 +266,7 @@ where
  * is that Vec is faster on small queue sizes
  * in most cases Vec.len = 1 so we just take first item in iteration.
  */
-fn find_sender(queue: &Queue, msgid: u64) -> Sender {
+fn find_sender(queue: &Queue, msgid: i64) -> Sender {
     let mut queue = queue.lock().unwrap();
 
     let pos = queue.iter().position(|req| req.0 == msgid).unwrap();

--- a/src/rpc/model.rs
+++ b/src/rpc/model.rs
@@ -243,12 +243,6 @@ impl IntoVal<Value> for u64 {
     }
 }
 
-impl IntoVal<Value> for i64 {
-    fn into_val(self) -> Value {
-        Value::from(self)
-    }
-}
-
 impl IntoVal<Value> for String {
     fn into_val(self) -> Value {
         Value::from(self)

--- a/src/rpc/model.rs
+++ b/src/rpc/model.rs
@@ -8,12 +8,12 @@ use std::io::{Read, Write};
 #[derive(Debug, PartialEq, Clone)]
 pub enum RpcMessage {
     RpcRequest {
-        msgid: i64,
+        msgid: u64,
         method: String,
         params: Vec<Value>,
     }, // 0
     RpcResponse {
-        msgid: i64,
+        msgid: u64,
         error: Value,
         result: Value,
     }, // 1
@@ -37,7 +37,7 @@ macro_rules! try_str {
 
 macro_rules! try_int {
     ($exp:expr, $msg:expr) => {
-        match $exp.as_i64() {
+        match $exp.as_u64() {
             Some(val) => val,
             _ => return Err(Box::new(io::Error::new(io::ErrorKind::Other, $msg))),
         }

--- a/src/rpc/model.rs
+++ b/src/rpc/model.rs
@@ -243,6 +243,12 @@ impl IntoVal<Value> for u64 {
     }
 }
 
+impl IntoVal<Value> for i64 {
+    fn into_val(self) -> Value {
+        Value::from(self)
+    }
+}
+
 impl IntoVal<Value> for String {
     fn into_val(self) -> Value {
         Value::from(self)

--- a/src/rpc/model.rs
+++ b/src/rpc/model.rs
@@ -8,12 +8,12 @@ use std::io::{Read, Write};
 #[derive(Debug, PartialEq, Clone)]
 pub enum RpcMessage {
     RpcRequest {
-        msgid: u64,
+        msgid: i64,
         method: String,
         params: Vec<Value>,
     }, // 0
     RpcResponse {
-        msgid: u64,
+        msgid: i64,
         error: Value,
         result: Value,
     }, // 1
@@ -37,7 +37,7 @@ macro_rules! try_str {
 
 macro_rules! try_int {
     ($exp:expr, $msg:expr) => {
-        match $exp.as_u64() {
+        match $exp.as_i64() {
             Some(val) => val,
             _ => return Err(Box::new(io::Error::new(io::ErrorKind::Other, $msg))),
         }
@@ -165,18 +165,18 @@ impl<T: FromVal<Value>> FromVal<Value> for Vec<T> {
     }
 }
 
-impl FromVal<Value> for (u64, u64) {
+impl FromVal<Value> for (i64, i64) {
     fn from_val(val: Value) -> Self {
         let res = val
             .as_array()
-            .expect("Can't convert to point(u64,u64) value");
+            .expect("Can't convert to point(i64,i64) value");
         if res.len() != 2 {
             panic!("Array length must be 2");
         }
 
         (
-            res[0].as_u64().expect("Can't get u64 value at position 0"),
-            res[1].as_u64().expect("Can't get u64 value at position 1"),
+            res[0].as_i64().expect("Can't get i64 value at position 0"),
+            res[1].as_i64().expect("Can't get i64 value at position 1"),
         )
     }
 }
@@ -196,9 +196,9 @@ impl FromVal<Value> for String {
     }
 }
 
-impl FromVal<Value> for u64 {
+impl FromVal<Value> for i64 {
     fn from_val(val: Value) -> Self {
-        val.as_u64().expect("Can't convert to u64")
+        val.as_i64().expect("Can't convert to i64")
     }
 }
 
@@ -225,7 +225,7 @@ impl IntoVal<Value> for Vec<Value> {
     }
 }
 
-impl IntoVal<Value> for (u64, u64) {
+impl IntoVal<Value> for (i64, i64) {
     fn into_val(self) -> Value {
         Value::from(vec![Value::from(self.0), Value::from(self.1)])
     }
@@ -237,7 +237,7 @@ impl IntoVal<Value> for bool {
     }
 }
 
-impl IntoVal<Value> for u64 {
+impl IntoVal<Value> for i64 {
     fn into_val(self) -> Value {
         Value::from(self)
     }


### PR DESCRIPTION
This PR adds support for negative indices in `Buffer.setLines`.

Excerpt from the `nvim_buf_set_lines` documentation:

_"Indexing is zero-based, end-exclusive. Negative indices are interpreted as length+1+index: -1 refers to the index past the end. So to change or delete the last element use start=-2 and end=-1."_

Example usage:
```
buffers[0].set_lines(&mut nvim, -1, -1, true, vec!["append to buffer".to_owned()]).unwrap();
```