### PR TITLE
Run handlers in a different thread than io

### DIFF
--- a/src/rpc/client.rs
+++ b/src/rpc/client.rs
@@ -34,7 +34,7 @@ where
 {
     reader: Option<BufReader<R>>,
     writer: Arc<Mutex<BufWriter<W>>>,
-    dispatch_guard: Option<JoinHandle<()>>,
+    dispatch_guard: Option<(JoinHandle<()>, JoinHandle<()>)>,
     event_loop_started: bool,
     queue: Queue,
     msgid_counter: u64,
@@ -45,7 +45,7 @@ where
     R: Read + Send + 'static,
     W: Write + Send + 'static,
 {
-    pub fn take_dispatch_guard(&mut self) -> JoinHandle<()> {
+    pub fn take_dispatch_guard(&mut self) -> (JoinHandle<()>, JoinHandle<()>) {
         self.dispatch_guard
             .take()
             .expect("Can only take join handle after running event loop")
@@ -143,7 +143,7 @@ where
                     }
                 }
                 Err(mpsc::TryRecvError::Disconnected) => {
-                    return Err(Value::from(format!("Channel disconnected ({})", method)))
+                    return Err(Value::from(format!("Channel disconnected ({})", method)));
                 }
                 Ok(val) => return val,
             };
@@ -226,27 +226,19 @@ where
         mut reader: BufReader<R>,
         writer: Arc<Mutex<BufWriter<W>>>,
         mut handler: H,
-    ) -> JoinHandle<()>
+    ) -> (JoinHandle<()>, JoinHandle<()>)
     where
         H: Handler + Send + 'static,
     {
-        thread::spawn(move || loop {
-            let msg = match model::decode(&mut reader) {
-                Ok(msg) => msg,
-                Err(e) => {
-                    error!("Error while reading: {}", e);
-                    Self::send_error_to_callers(&queue, &e);
-                    return;
-                }
-            };
-            debug!("Get message {:?}", msg);
-            match msg {
-                model::RpcMessage::RpcRequest {
+        let (io_to_handlers, handlers_from_io) = mpsc::channel();
+        let rqjoin = thread::spawn(move || loop {
+            match handlers_from_io.recv() {
+                Ok(model::RpcMessage::RpcRequest {
                     msgid,
                     method,
                     params,
-                } => {
-                    let response = match handler.handle_request(&method, params) {
+                }) => {
+                    let response = match handler.handle_request(method, params) {
                         Ok(result) => model::RpcMessage::RpcResponse {
                             msgid,
                             result,
@@ -262,6 +254,31 @@ where
                     let writer = &mut *writer.lock().unwrap();
                     model::encode(writer, response).expect("Error sending RPC response");
                 }
+                Ok(model::RpcMessage::RpcNotification { method, params }) => {
+                    handler.handle_notify(&method, params);
+                }
+                Ok(_) => {
+                    error!("Handler threat does not handle notifications!");
+                }
+                Err(e) => {
+                    debug!("Error receiving request data: {:?}", e);
+                }
+            }
+        });
+        let iojoin = thread::spawn(move || loop {
+            error!("Beginning of io-loop!");
+            let msg = match model::decode(&mut reader) {
+                Ok(msg) => msg,
+                Err(e) => {
+                    error!("Error while reading: {}", e);
+                    Self::send_error_to_callers(&queue, &e);
+                    return;
+                }
+            };
+            match msg {
+                m @ model::RpcMessage::RpcRequest { .. } => {
+                    io_to_handlers.send(m).unwrap();
+                }
                 model::RpcMessage::RpcResponse {
                     msgid,
                     result,
@@ -274,11 +291,13 @@ where
                         sender.send(Ok(result));
                     }
                 }
-                model::RpcMessage::RpcNotification { method, params } => {
-                    handler.handle_notify(&method, params);
+                m @ model::RpcMessage::RpcNotification { .. } => {
+                    io_to_handlers.send(m).unwrap();
+                    //handler.handle_notify(&method, params);
                 }
             };
-        })
+        });
+        (rqjoin, iojoin)
     }
 }
 

--- a/src/rpc/handler.rs
+++ b/src/rpc/handler.rs
@@ -2,7 +2,7 @@ use rmpv::Value;
 use std::sync::mpsc;
 
 pub trait RequestHandler {
-    fn handle_request(&mut self, _name: &str, _args: Vec<Value>) -> Result<Value, Value> {
+    fn handle_request(&mut self, _name: String, _args: Vec<Value>) -> Result<Value, Value> {
         Err(Value::from("Not implemented"))
     }
 }
@@ -28,7 +28,7 @@ impl<H: RequestHandler> Handler for ChannelHandler<H> {
 }
 
 impl<H: RequestHandler> RequestHandler for ChannelHandler<H> {
-    fn handle_request(&mut self, name: &str, args: Vec<Value>) -> Result<Value, Value> {
+    fn handle_request(&mut self, name: String, args: Vec<Value>) -> Result<Value, Value> {
         self.request_handler.handle_request(name, args)
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -197,7 +197,7 @@ impl Session {
     /// Wait dispatch thread to finish.
     ///
     /// This can happens in case child process connection is lost for some reason.
-    pub fn take_dispatch_guard(&mut self) -> JoinHandle<()> {
+    pub fn take_dispatch_guard(&mut self) -> (JoinHandle<()>, JoinHandle<()>) {
         match self.client {
             ClientConnection::Child(ref mut client, _) => client.take_dispatch_guard(),
             ClientConnection::Parent(ref mut client) => client.take_dispatch_guard(),


### PR DESCRIPTION
Hey!

I've run into a race condition with neovim-lib: If we recieve a `Request`, then the handler for that request blocks the iO thread (I'm calling it the iO thread, it's the one spawned by `dispatch_thread`). That's a problem for 2 related reasons:

1. The handler itself might run requests to neovim, but the response can't be handled by the iO thread, since it's blocked by the handler.
2. If the main thread is just busy doing something else when the request arrives, it might itself request some data from neovim, but will never receive the response, since the iO thread is blocked by the handler.

Both times, a timeout is the result. I've run into 2. because the request during a test would arrive faster than my main thread could reach it's event loop, and when it requested the current buffer to set up things, it would never get an answer because the request was already blocking the iO thread.

So here's a rough shot at fixing this. The iO thread sends Requests/Notifications to another thread, which handels those, while the iO thread stays free to get more events, in particular responses. The new thread needs to take ownership of the closed variables (notably, the handler itself), which implied that we need to change the signature of the handler functions to take `String` instead of `&str`. It's not a problem per se (we weren't doing anything with the method name anyways other than passing it to the handler), but it's a breaking change.

Also, I've opted to saving the new threads handle in the `dispatch_guard`. I've also not fully polished that, let me know what you think and I'll clean up the `unwrap`s.

CC @bfredl @vhakulinen 