### PR TITLE
Remove rmp from dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,6 @@ name = "neovim-lib"
 version = "0.6.0"
 dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rmp 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "rmpv 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "unix_socket 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ exclude = ["generate.bat", "Makefile"]
 travis-ci = { repository = "daa84/neovim-lib", branch = "master"  }
 
 [dependencies]
-rmp = "0.8"
 rmpv = { version ="0.4", features=["with-serde"] }
 log = "0.4"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,6 @@
 //! let (event_name, args) = receiver.recv().unwrap();
 //!
 //! ```
-extern crate rmp;
 extern crate rmpv;
 #[macro_use]
 extern crate log;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,5 +1,4 @@
 extern crate neovim_lib;
-extern crate rmp;
 extern crate tempdir;
 
 use neovim_lib::session::Session;


### PR DESCRIPTION
I think neovim-lib moves without rmp and rmp is not re-exported.