### PR TITLE
Add handle_close method to handler

### DIFF
--- a/src/rpc/client.rs
+++ b/src/rpc/client.rs
@@ -235,6 +235,7 @@ where
                 Ok(msg) => msg,
                 Err(e) => {
                     error!("Error while reading: {}", e);
+                    handler.handle_close();
                     Self::send_error_to_callers(&queue, &e);
                     return;
                 }

--- a/src/rpc/handler.rs
+++ b/src/rpc/handler.rs
@@ -9,6 +9,8 @@ pub trait RequestHandler {
 
 pub trait Handler: RequestHandler {
     fn handle_notify(&mut self, _name: &str, _args: Vec<Value>) {}
+
+    fn handle_close(&mut self) { }
 }
 
 pub struct DefaultHandler();


### PR DESCRIPTION
handle_close method is called when the read thread exists after a
io/decode error.