### PR TITLE
rmpv v0.4 doesn't build anymore

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 travis-ci = { repository = "daa84/neovim-lib", branch = "master"  }
 
 [dependencies]
-rmpv = { version ="0.4", features=["with-serde"] }
+rmpv = { version ="1.3.1", features=["with-serde"] }
 log = "0.4"
 
 [target.'cfg(unix)'.dependencies]

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -5,5 +5,4 @@ pub mod model;
 pub use self::client::Client;
 pub use self::model::FromVal;
 pub use self::model::IntoVal;
-pub use self::model::RpcMessage;
 pub use rmpv::Value;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -76,7 +76,7 @@ fn can_connect_via_unix_socket() {
             }
 
             if one_second <= start.elapsed() {
-                panic!(format!("neovim socket not found at '{:?}'", &socket_path));
+                panic!("neovim socket not found at '{:?}'", &socket_path);
             }
         }
     }
@@ -98,17 +98,17 @@ fn can_connect_via_unix_socket() {
     match servername.as_str() {
         Some(ref name) => {
             if Path::new(name) != socket_path {
-                panic!(format!(
+                panic!(
                     "Server name does not match socket path! {} != {}",
                     name,
                     socket_path.to_str().unwrap()
-                ));
+                );
             }
         }
-        None => panic!(format!(
+        None => panic!(
             "Server name does not match socket path! {:?} != {}",
             servername,
             socket_path.to_str().unwrap()
-        )),
+        ),
     }
 }


### PR DESCRIPTION
neovim-libs dependency on rmpv v0.4 doesn't build anymore. This seems to have something to do with functionality being removed from rmp in newer versions, and as no lock file is provided, cargo will try to use this newer version.

I tried to bump rmpv to 1.3.1 and run the provided tests, which seemed to work.

I also ran cargo fix that solved a couple of warnings from language changes.